### PR TITLE
Add the Datadog profiler as an option for the Tracer

### DIFF
--- a/telemetry/datadog.go
+++ b/telemetry/datadog.go
@@ -27,9 +27,15 @@ type DataDog struct{}
 
 // DataDogConfig is the struct of config given to NewDataDog.
 type DataDogConfig struct {
-	Env          string `env:"ENV,required"`
-	Service      string `env:"SERVICE,required"`
-	Version      string
+	Env     string `env:"ENV,required"`
+	Service string `env:"SERVICE,required"`
+	Version string
+
+	// WithProfiler enables application profiling with Datadog's Profiler, reads
+	// directly from optional environment variable WITH_PROFILER.
+	// Although datadog claims low overhead with negligible impact in performance
+	// for production workloads, beaware enabling it may cause performance impacts
+	// in your application. We recommend enabling only when needed.
 	WithProfiler bool `env:"WITH_PROFILER"`
 }
 

--- a/telemetry/datadog.go
+++ b/telemetry/datadog.go
@@ -111,5 +111,6 @@ func startProfiler(config DataDogConfig) error {
 	if err != nil {
 		return errors.Wrap(err, "unable to start datadog profiler")
 	}
+
 	return nil
 }

--- a/telemetry/datadog.go
+++ b/telemetry/datadog.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/pkg/errors"
 	ddchi "gopkg.in/DataDog/dd-trace-go.v1/contrib/go-chi/chi.v5"
 	ddhttp "gopkg.in/DataDog/dd-trace-go.v1/contrib/net/http"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
 )
 
 const (
@@ -25,20 +27,28 @@ type DataDog struct{}
 
 // DataDogConfig is the struct of config given to NewDataDog.
 type DataDogConfig struct {
-	Env     string `env:"ENV,required"`
-	Service string `env:"SERVICE,required"`
-	Version string
+	Env          string `env:"ENV,required"`
+	Service      string `env:"SERVICE,required"`
+	Version      string
+	WithProfiler bool
 }
 
 // NewDataDog returns a new Datadog implementation.
-func NewDataDog(config DataDogConfig) *DataDog {
+func NewDataDog(config DataDogConfig) (*DataDog, error) {
 	tracer.Start([]tracer.StartOption{
 		tracer.WithEnv(config.Env),
 		tracer.WithService(config.Service),
 		tracer.WithServiceVersion(config.Version),
 	}...)
 
-	return &DataDog{}
+	if config.WithProfiler {
+		err := startProfiler(config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &DataDog{}, nil
 }
 
 // Middleware add into http framework datadog tracer to track each requisition.
@@ -83,4 +93,23 @@ func (DataDog) SpanFromContext(ctx context.Context) (Span, bool) {
 // Client receive *http.Client and return a *http.Client with datadog tracer wrapped in it.
 func Client(parent *http.Client) *http.Client {
 	return ddhttp.WrapClient(parent)
+}
+
+// startProfiler handles initialization of the datadog profiler, errors out
+// when it can't find an agent or APIKey.
+func startProfiler(config DataDogConfig) error {
+	err := profiler.Start(
+		profiler.WithService(config.Service),
+		profiler.WithEnv(config.Env),
+		profiler.WithVersion(config.Version),
+		profiler.WithProfileTypes(
+			profiler.CPUProfile,
+			profiler.HeapProfile,
+			profiler.GoroutineProfile,
+		),
+	)
+	if err != nil {
+		return errors.Wrap(err, "unable to start datadog profiler")
+	}
+	return nil
 }

--- a/telemetry/datadog.go
+++ b/telemetry/datadog.go
@@ -30,7 +30,7 @@ type DataDogConfig struct {
 	Env          string `env:"ENV,required"`
 	Service      string `env:"SERVICE,required"`
 	Version      string
-	WithProfiler bool
+	WithProfiler bool `env:"WITH_PROFILER"`
 }
 
 // NewDataDog returns a new Datadog implementation.

--- a/telemetry/go.mod
+++ b/telemetry/go.mod
@@ -10,10 +10,12 @@ require (
 
 require (
 	github.com/DataDog/datadog-go v4.4.0+incompatible // indirect
+	github.com/DataDog/gostackparse v0.5.0 // indirect
 	github.com/DataDog/sketches-go v1.0.0 // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/go-chi/chi/v5 v5.0.7 // indirect
 	github.com/golang/protobuf v1.4.1 // indirect
+	github.com/google/pprof v0.0.0-20210423192551-a2663126120b // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/philhofer/fwd v1.1.1 // indirect

--- a/telemetry/go.sum
+++ b/telemetry/go.sum
@@ -2,6 +2,7 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/DataDog/datadog-go v4.4.0+incompatible h1:R7WqXWP4fIOAqWJtUKmSfuc7eDsBT58k9AY5WSHVosk=
 github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/gostackparse v0.5.0 h1:jb72P6GFHPHz2W0onsN51cS3FkaMDcjb0QzgxxA4gDk=
 github.com/DataDog/gostackparse v0.5.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/sketches-go v1.0.0 h1:chm5KSXO7kO+ywGWJ0Zs6tdmWU8PBXSbywFVciL6BG4=
 github.com/DataDog/sketches-go v1.0.0/go.mod h1:O+XkJHWk9w4hDwY2ZUDU31ZC9sNYlYo8DiFsxjYeo1k=
@@ -40,6 +41,7 @@ github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
 github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/pprof v0.0.0-20210423192551-a2663126120b h1:l2YRhr+YLzmSp7KJMswRVk/lO5SwoFIcCLzJsVj+YPc=
 github.com/google/pprof v0.0.0-20210423192551-a2663126120b/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=


### PR DESCRIPTION
Enabling the Datadog profiler will increase the observability of our applications.

Datadog's profiler documentation: 
- [https://docs.datadoghq.com/tracing/profiler/enabling/go/](https://docs.datadoghq.com/tracing/profiler/enabling/go/)
- [https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler)

Because the profiler initializer returns an error it was necessary to change NewDataDog return parameters to handle this error.

-----

- feat: add datadog profiler to tracer with config
BREAKING CHANGE: NewDataDog now returns an error as second value