### PR TITLE
Enable runtime metrics on Datadog

### DIFF
--- a/telemetry/datadog.go
+++ b/telemetry/datadog.go
@@ -45,6 +45,7 @@ func NewDataDog(config DataDogConfig) (*DataDog, error) {
 		tracer.WithEnv(config.Env),
 		tracer.WithService(config.Service),
 		tracer.WithServiceVersion(config.Version),
+		tracer.WithRuntimeMetrics(),
 	}...)
 
 	if config.WithProfiler {


### PR DESCRIPTION
This PR aims to enable runtime metrics by `default`. More [here](https://docs.datadoghq.com/tracing/runtime_metrics/go/)