### PR TITLE
feat!: enrich new relic implentation

### DIFF
--- a/telemetry/datadog_span.go
+++ b/telemetry/datadog_span.go
@@ -14,11 +14,11 @@ func (dd *ddSpan) Context() SpanContext {
 	return &dd.context
 }
 
-func (dd *ddSpanContext) SpanID() uint64 {
+func (dd *ddSpanContext) SpanID() interface{} {
 	return dd.spanID
 }
 
-func (dd *ddSpanContext) TraceID() uint64 {
+func (dd *ddSpanContext) TraceID() interface{} {
 	return dd.traceID
 }
 

--- a/telemetry/interface.go
+++ b/telemetry/interface.go
@@ -33,10 +33,10 @@ type Span interface {
 // SpanContext handle spans in context.
 type SpanContext interface {
 	// SpanID Return the SpanID
-	SpanID() uint64
+	SpanID() interface{}
 
 	// TraceID returns the trace ID that this context is carrying.
-	TraceID() uint64
+	TraceID() interface{}
 
 	ToMap() map[string]interface{}
 }


### PR DESCRIPTION
BREAKING CHANGE: SpanContext interface return types change to interface{} to allow
broader types to be used.

If you do not implement your own Tracer nothing change.